### PR TITLE
If the same streaming key is received, the existing stream is disconnected.

### DIFF
--- a/sources/thelib/include/streaming/streamsmanager.h
+++ b/sources/thelib/include/streaming/streamsmanager.h
@@ -67,6 +67,13 @@ public:
 	void UnRegisterStreams(uint32_t protocolId);
 
 	/*!
+		@brief Erases the stream to the streams manager using the stream name and protocol ID.
+		@param streamName
+		@param protocolId
+	 */
+	void UnRegisterStreams(string streamName, uint32_t protocolId);
+
+	/*!
 		@brief Checks and see if the duplicate inbound network streams are available. Always returns true if allowDuplicateNetworkStreams is set to true inside the config file
 		@param streamName - The stream name we want to see is free or not
 	 */

--- a/sources/thelib/src/protocols/rtp/connectivity/inboundconnectivity.cpp
+++ b/sources/thelib/src/protocols/rtp/connectivity/inboundconnectivity.cpp
@@ -210,8 +210,8 @@ bool InboundConnectivity::Initialize() {
 	if (_streamName == "")
 		_streamName = format("rtsp_%u", _pRTSP->GetId());
 	if (!pApplication->StreamNameAvailable(_streamName, _pRTSP)) {
-		FATAL("Stream name %s already taken", STR(_streamName));
-		return false;
+		INFO("Stream name %s already taken", STR(_streamName));
+		pApplication->GetStreamsManager()->UnRegisterStreams(_streamName, _pRTSP->GetId());
 	}
 	_pInStream = new InNetRTPStream(_pRTSP, _streamName, _videoTrack, _audioTrack,
 			bandwidth, _rtcpDetectionInterval);

--- a/sources/thelib/src/streaming/streamsmanager.cpp
+++ b/sources/thelib/src/streaming/streamsmanager.cpp
@@ -78,6 +78,14 @@ void StreamsManager::UnRegisterStreams(uint32_t protocolId) {
 	}
 }
 
+void StreamsManager::UnRegisterStreams(string streamName, uint32_t protocolId) {
+	map<uint32_t, BaseStream *> streams = FindByProtocolIdByTypeByName(protocolId, ST_IN_NET, streamName, true, false);
+
+	FOR_MAP(streams, uint32_t, BaseStream *, i) {
+		UnRegisterStream(MAP_VAL(i));
+	}
+}
+
 bool StreamsManager::StreamNameAvailable(string streamName) {
 	return FindByTypeByName(ST_IN_NET, streamName, true, false).size() == 0;
 }


### PR DESCRIPTION
If there was an existing connection, the server did not accept a new connection.
Allowed the client to reconnect without waiting for a timeout, even if the client did not disconnect.